### PR TITLE
Refactor to use a single INI format config file

### DIFF
--- a/development-example.ini
+++ b/development-example.ini
@@ -1,4 +1,23 @@
 ###
+# database details; table names used in setup_db.py only
+###
+
+[connection_info]
+dbname = otindex
+dbuser = postgres
+password = 
+
+[database_tables]
+curatorstudytable = curator_study_map
+treeotutable = tree_otu_map
+curatortable = curator
+treetable = tree
+studytable = study
+otttable = taxonomy
+synonymtable = synonym
+propertytable = property
+
+###
 # app configuration
 # http://docs.pylonsproject.org/projects/pyramid/en/1.5-branch/narr/environment.html
 ###

--- a/otindex/models.py
+++ b/otindex/models.py
@@ -143,7 +143,8 @@ class Taxonomy(Base):
 # )
 class Synonym(Base):
     __tablename__='synonym'
-    id = Column(Integer,ForeignKey("taxonomy.id"),primary_key=True)
+    id = Column(Integer,primary_key=True)
+    ott_id = Column(Integer,ForeignKey("taxonomy.id"))
     synonym = Column(String)
 
 # property table

--- a/otindex/scripts/README.md
+++ b/otindex/scripts/README.md
@@ -39,24 +39,18 @@ The methods in `setup_db.py` call SQL `CREATE TABLE` directly using psycopg2.
 These methods are leftover from early development of the database schema, and it
 is possible that the CREATE statements may drift from the table definitions in
 `models.py` over time. Use at your own risk (and if you get errors, change the
-table defs here, not in models.py).
+table defs in `setup_db.py` to match `models.py`, not the other way around).
 
 ## Loading data
-
-To load data into the database:
-
-* `config.yml`: YAML file with database settings, including table names.
-* `run_setup_scripts.sh`: bash script that runs the setup python files listed below. Takes as arguments a config file (required) and an integer (optional) that is the number of studies to load (default = load whole phylesystem)
-* `setup_db.py`: creates DB tables if do not already exist; optionally deleting them all first
-* `load_nexson.py`: loads the nexson files into the database and creates the JSON index
-* `load_taxonomy.py`: loads the taxonomy files into the database
-* `create\_otu\_table.py`: generates a csv file of otu-tree relationships and then loads this using the COPY command
-* `test_db_selects.py`: does a few simple selects on study and tree table
 
 To run all of the data load steps:
       `$ bash run_setup_scripts.sh config.yml {n}`
 
-where n = number studies (optional; default is load all).
+where n = number studies (optional; default is load all). Note that this method
+only clears existing tables, it does not re-create them. If you want to create
+the tables (noting that you should really do this using the
+`initialize_otindex_db` script, see above) then you will need to run the steps
+individually.
 
 Or, you can run the steps individually:
 

--- a/otindex/scripts/create_otu_table.py
+++ b/otindex/scripts/create_otu_table.py
@@ -38,86 +38,6 @@ def getTreeID(cursor,study_id,tree_id):
         raise LookupError('study {s}, tree {t}'
             ' not found'.format(s=study_id,t=tree_id))
 
-# Get association between trees and mapped OTUs in all studies
-# def prepare_csv_files(connection,cursor,phy,taxonomy,nstudies=None):
-#     otu_filename = "otu_mapping.csv"
-#     tree_otu_filename = "tree_otu_assoc.csv"
-#     seen_otus = {}
-#
-#     # need this to look up taxonomy names from ott_ids later
-#     ott_names = taxonomy.ott_id_to_names
-#
-#     with open(otu_filename, 'w') as f, open(tree_otu_filename, 'w') as g:
-#         fwriter = csv.writer(f)
-#         gwriter = csv.writer(g)
-#         # datafile format is 'ottid'\t'treeid' where treeid is not
-#         # the treeid (string) in the nexson, but the treeid (int) from
-#         # the database for faster indexing
-#         counter = 0
-#         fwriter.writerow(('id','name'))
-#         for study_id, n in phy.iter_study_objs():
-#             otu_dict = gen_otu_dict(n)
-#             # iterate over the OTUs in the study, collecting the mapped
-#             # ones (oid to ott_id mapping held at the study level)
-#             mapped_otus = {}
-#             for oid, o in otu_dict.items():
-#                 ottID = o.get('^ot:ottId')
-#                 if ottID is not None:
-#                     label = o['^ot:originalLabel']
-#                     ottname = o.get('^ot:ottTaxonName')
-#                     if ottname is None:
-#                         ottname = 'unnamed'
-#                     if ottID not in seen_otus:
-#                         # print ottID,ottname
-#                         fwriter.writerow((ottID,ottname))
-#                         seen_otus[ottID] = ottname
-#                     otu_props = (ottname,ottID)
-#                     mapped_otus[oid] = otu_props
-#
-#             # iterate over the trees in the study, collecting
-#             # tree/otu associations (including lineage)
-#             print "collecting tree / otu associations"
-#             for trees_group_id, tree_id, tree in iter_trees(n):
-#                 # the unique identifier in the tree table is an auto-incrementing
-#                 # int, not the tree_id in the nexson, which is not unique
-#                 tree_int_id = getTreeID(cursor,study_id,tree_id)
-#                 ottIDs = {}     # all ids for this tree
-#                 # the tree nodes have node_ids, otu ids (if tips), and ott_ids
-#                 # (if mapped to OTT taxa)
-#                 for node_id, node in iter_node(tree):
-#                     oid = node.get('@otu')
-#                     # no @otu property on internal nodes
-#                     if oid is not None:
-#                         # see if there is an ott_id associated with this oid
-#                         otu_props = mapped_otus.get(oid)
-#                         if otu_props is not None:
-#                             ottID = otu_props[1]
-#                             print study_id,tree_id,ottID
-#                             ottIDs[ottID] = True
-#                             #print tree_id,oid,ottID
-#                 print "starting ottids: {l}".format(l=len(ottIDs))
-#                 ottIDs = parent_closure(ottIDs,taxonomy)
-#                 print "ending ottids: {l}".format(l=len(ottIDs))
-#                 for ottID in ottIDs:
-#                     if ottID not in seen_otus:
-#                         # get ott name from dictionary, value might be string
-#                         # or might be list
-#                         ottname = ott_names[ottID]
-#                         if (isinstance(ottname,tuple)):
-#                             ottname = ottname[0]
-#                         fwriter.writerow((ottID,ottname))
-#                         seen_otus[ottID] = ottname
-#                     gwriter.writerow((tree_int_id,ottID))
-#
-#             counter+=1
-#             if (counter%500 == 0):
-#                 print " prepared",counter,"studies"
-#             if (nstudies and counter>=nstudies):
-#                 f.close()
-#                 g.close()
-#                 break
-#     return (otu_filename, tree_otu_filename)
-
 def prepare_otu_tree_file(connection,cursor,phy,taxonomy,nstudies=None):
     tree_otu_filename = "tree_otu_assoc.csv"
 
@@ -201,29 +121,25 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # read config variables
-    config_dict={}
-    with open(args.configfile,'r') as f:
-        config_dict = yaml.safe_load(f)
+    config_obj = setup_db.read_config(args.configfile)
 
-    ott_loc = config_dict['taxonomy']
-    if ott_loc == 'None':
-        print 'No taxonomy'
-        taxonomy = None
-    else:
-        print "Loading taxonomy into memory"
-        taxonomy = ott.OTT(ott_loc)
+    # ott_loc = config_dict['taxonomy']
+    # if ott_loc == 'None':
+    #     print 'No taxonomy'
+    #     taxonomy = None
+    # else:
+    #     print "Loading taxonomy into memory"
+    #     taxonomy = ott.OTT(ott_loc)
 
-    connection, cursor = setup_db.connect(config_dict)
+    # load taxonomy; location from peyotl config
+    taxonomy = ott.OTT()
+    connection, cursor = setup_db.connect(config_obj)
     phy = create_phylesystem_obj()
     try:
-        # OTUTABLE = config_dict['tables']['otutable']
-        TREEOTUTABLE = config_dict['tables']['treeotutable']
+        TREEOTUTABLE = config_obj.get('database_tables','treeotutable')
         setup_db.clear_single_table(connection,cursor,TREEOTUTABLE)
         print 'Preparing tree - otu association file'
-        # (otu_filename, tree_otu_filename) = prepare_csv_files(connection,cursor,phy,taxonomy,args.nstudies)
         tree_otu_filename = prepare_otu_tree_file(connection,cursor,phy,taxonomy,args.nstudies)
-        #print 'Importing otus'
-        # setup_db.import_csv_file(connection,cursor,OTUTABLE,otu_filename)
         print 'Importing tree/otus'
         setup_db.import_csv_file(connection,cursor,TREEOTUTABLE,tree_otu_filename)
     except psy.Error as e:

--- a/otindex/scripts/load_nexson.py
+++ b/otindex/scripts/load_nexson.py
@@ -46,8 +46,8 @@ def insert_curators(connection,cursor,config_obj,study_id,curators):
         s=study_id)
         )
     try:
-        CURATORTABLE = config_obj.get('tables','curatortable')
-        CURATORSTUDYTABLE = config_obj.get('tables','curatorstudytable')
+        CURATORTABLE = config_obj.get('database_tables','curatortable')
+        CURATORSTUDYTABLE = config_obj.get('database_tables','curatorstudytable')
         for name in curators:
             name = to_unicode(name)
             _LOG.debug(u'Loading curator {c}'.format(c=name))
@@ -125,7 +125,7 @@ def load_nexsons(connection,cursor,phy,config_obj,nstudies=None):
         #print 'STUDY: ',study_id
         study_properties.update(nexml.keys())
         # study data for study table
-        STUDYTABLE = config_obj.get('tables','studytable')
+        STUDYTABLE = config_obj.get('database_tables','studytable')
         year = nexml.get('^ot:studyYear')
         proposedTrees = nexml.get('^ot:candidateTreeForSynthesis')
         if proposedTrees is None:
@@ -175,7 +175,7 @@ def load_nexsons(connection,cursor,phy,config_obj,nstudies=None):
         # iterate over trees and insert tree data
         # note that OTU data done separately as COPY
         # due to size of table (see script <scriptname>)
-        TREETABLE = config_obj.get('tables','treetable')
+        TREETABLE = config_obj.get('database_tables','treetable')
         ntrees = 0
         try:
             for trees_group_id, tree_id, tree in iter_trees(studyobj):
@@ -228,7 +228,7 @@ def load_nexsons(connection,cursor,phy,config_obj,nstudies=None):
             break
 
     # load the tree and study properties
-    PROPERTYTABLE = config_obj.get('tables','propertytable')
+    PROPERTYTABLE = config_obj.get('database_tables','propertytable')
     load_properties(
         connection,
         cursor,
@@ -257,13 +257,13 @@ if __name__ == "__main__":
     # and clear data, except taxonomy table
     try:
         tabledict = dict(config_obj.items('database_tables'))
-        for table in [tabledict]:
+        for table in tabledict:
             # skip the taxonomy table, which does note get loaded here
             if table == "otttable":
                 continue
             name = tabledict[table]
             if setup_db.table_exists(cursor,name):
-                setup_db.clear_single_tables(connection,cursor,name)
+                setup_db.clear_single_table(connection,cursor,name)
             else:
                 raise psy.ProgrammingError("Table {t} does not exist".format(t=name))
         setup_db.clear_gin_index(connection,cursor)

--- a/otindex/scripts/load_nexson.py
+++ b/otindex/scripts/load_nexson.py
@@ -250,7 +250,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # read config variables
-    config_obj = setup_db.read_config(configfile)
+    config_obj = setup_db.read_config(args.configfile)
     connection, cursor = setup_db.connect(config_obj)
 
     # test that tables exist

--- a/otindex/scripts/load_nexson.py
+++ b/otindex/scripts/load_nexson.py
@@ -240,7 +240,7 @@ if __name__ == "__main__":
     # get command line argument (nstudies to import)
     parser = argparse.ArgumentParser(description='load nexsons into postgres')
     parser.add_argument('configfile',
-        help='path to the config file'
+        help='path to the development.ini file'
         )
     parser.add_argument('-n',
         dest='nstudies',

--- a/otindex/scripts/load_nexson.py
+++ b/otindex/scripts/load_nexson.py
@@ -40,14 +40,14 @@ def to_unicode(text):
 
 # iterate over curators, adding curators to curator table and the
 # who-curated-what relationship to study-curator-map
-def insert_curators(connection,cursor,config_dict,study_id,curators):
+def insert_curators(connection,cursor,config_obj,study_id,curators):
     _LOG.debug(u'Loading {n} curators for study {s}'.format(
         n=len(curators),
         s=study_id)
         )
     try:
-        CURATORTABLE = config_dict['tables']['curatortable']
-        CURATORSTUDYTABLE = config_dict['tables']['curatorstudytable']
+        CURATORTABLE = config_obj.get('tables','curatortable')
+        CURATORSTUDYTABLE = config_obj.get('tables','curatorstudytable')
         for name in curators:
             name = to_unicode(name)
             _LOG.debug(u'Loading curator {c}'.format(c=name))
@@ -116,7 +116,7 @@ def load_properties(connection,cursor,prop_table,study_props,tree_props):
         connection.commit()
 
 # iterate over phylesystem nexsons and import
-def load_nexsons(connection,cursor,phy,config_dict,nstudies=None):
+def load_nexsons(connection,cursor,phy,config_obj,nstudies=None):
     counter = 0
     study_properties = set()
     tree_properties = set()
@@ -125,7 +125,7 @@ def load_nexsons(connection,cursor,phy,config_dict,nstudies=None):
         #print 'STUDY: ',study_id
         study_properties.update(nexml.keys())
         # study data for study table
-        STUDYTABLE = config_dict['tables']['studytable']
+        STUDYTABLE = config_obj.get('tables','studytable')
         year = nexml.get('^ot:studyYear')
         proposedTrees = nexml.get('^ot:candidateTreeForSynthesis')
         if proposedTrees is None:
@@ -170,12 +170,12 @@ def load_nexsons(connection,cursor,phy,config_dict,nstudies=None):
             curators=c
         # remove duplicates
         curators = list(set(curators))
-        insert_curators(connection,cursor,config_dict,study_id,curators)
+        insert_curators(connection,cursor,config_obj,study_id,curators)
 
         # iterate over trees and insert tree data
         # note that OTU data done separately as COPY
         # due to size of table (see script <scriptname>)
-        TREETABLE = config_dict['tables']['treetable']
+        TREETABLE = config_obj.get('tables','treetable')
         ntrees = 0
         try:
             for trees_group_id, tree_id, tree in iter_trees(studyobj):
@@ -228,7 +228,7 @@ def load_nexsons(connection,cursor,phy,config_dict,nstudies=None):
             break
 
     # load the tree and study properties
-    PROPERTYTABLE = config_dict['tables']['propertytable']
+    PROPERTYTABLE = config_obj.get('tables','propertytable')
     load_properties(
         connection,
         cursor,
@@ -250,22 +250,23 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # read config variables
-    config_dict={}
-    with open(args.configfile,'r') as f:
-        config_dict = yaml.safe_load(f)
-
-    connection, cursor = setup_db.connect(config_dict)
+    config_obj = setup_db.read_config(configfile)
+    connection, cursor = setup_db.connect(config_obj)
 
     # test that tables exist
-    # and clear data
+    # and clear data, except taxonomy table
     try:
-        tabledict = config_dict['tables']
-        for table in tabledict:
+        tabledict = dict(config_obj.items('database_tables'))
+        for table in [tabledict]:
+            # skip the taxonomy table, which does note get loaded here
+            if table == "otttable":
+                continue
             name = tabledict[table]
-            if not setup_db.table_exists(cursor,name):
+            if setup_db.table_exists(cursor,name):
+                setup_db.clear_single_tables(connection,cursor,name)
+            else:
                 raise psy.ProgrammingError("Table {t} does not exist".format(t=name))
-        setup_db.clear_tables(connection,cursor,config_dict)
-        setup_db.clear_gin_index(connection,cursor,config_dict)
+        setup_db.clear_gin_index(connection,cursor)
         print "done clearing tables and index"
     except psy.Error as e:
         print e.pgerror
@@ -277,13 +278,13 @@ if __name__ == "__main__":
         phy = create_phylesystem_obj()
         print "loading nexsons"
         if (args.nstudies):
-            load_nexsons(connection,cursor,phy,config_dict,args.nstudies)
+            load_nexsons(connection,cursor,phy,config_obj,args.nstudies)
         else:
-            load_nexsons(connection,cursor,phy,config_dict)
+            load_nexsons(connection,cursor,phy,config_obj)
         endtime = dt.datetime.now()
         print "Load time: ",endtime - starttime
         print "indexing JSONB columns in tree and study table"
-        setup_db.index_json_columns(connection,cursor,config_dict)
+        setup_db.index_json_columns(connection,cursor,config_obj)
     except psy.Error as e:
         print e.pgerror
     connection.close()

--- a/otindex/scripts/load_taxonomy.py
+++ b/otindex/scripts/load_taxonomy.py
@@ -18,7 +18,8 @@ import peyotl.ott as ott
 
 def load_taxonomy_using_copy(connection,cursor,otttable,syntable,path):
     print "Loading taxonomy into memory"
-    taxonomy = ott.OTT(path)
+    # if OTT dir not specified, uses path from peyotl config
+    taxonomy = ott.OTT()
     # get dictionary of ottids:ottnames, noting that the names can be strings
     # or tuples, e.g. (canonical name,synonym,synonym)
     ott_names = taxonomy.ott_id_to_names

--- a/otindex/scripts/load_taxonomy.py
+++ b/otindex/scripts/load_taxonomy.py
@@ -7,7 +7,7 @@
 import datetime as dt
 import argparse
 import psycopg2 as psy
-import csv, yaml, io, os
+import csv, io, os
 
 # other database functions
 import setup_db
@@ -75,26 +75,24 @@ if __name__ == "__main__":
     # get command line argument (nstudies to import)
     parser = argparse.ArgumentParser(description='load ott into postgres')
     parser.add_argument('configfile',
-        help='path to the config file'
+        help='path to the development.ini file'
         )
     args = parser.parse_args()
 
     # read config variables
-    config_dict={}
-    with open(args.configfile,'r') as f:
-        config_dict = yaml.safe_load(f)
+    config_obj = setup_db.read_config(configfile)
 
-    connection, cursor = setup_db.connect(config_dict)
+    connection, cursor = setup_db.connect(config_obj)
 
     # test that table exists
     # and clear data
     try:
         print "clearing OTT tables"
-        TAXONOMYTABLE = config_dict['tables']['otttable']
+        TAXONOMYTABLE = config_obj.get('tables','otttable')
         if not setup_db.table_exists(cursor,TAXONOMYTABLE):
             raise psy.ProgrammingError("Table {t} does not exist".format(t=TAXONOMYTABLE))
         setup_db.clear_single_table(connection,cursor,TAXONOMYTABLE)
-        SYNONYMTABLE = config_dict['tables']['synonymtable']
+        SYNONYMTABLE = config_obj.get('tables','synonymtable')
         if not setup_db.table_exists(cursor,SYNONYMTABLE):
             raise psy.ProgrammingError("Table {t} does not exist".format(t=SYNONYMTABLE))
         setup_db.clear_single_table(connection,cursor,SYNONYMTABLE)

--- a/otindex/scripts/load_taxonomy.py
+++ b/otindex/scripts/load_taxonomy.py
@@ -16,7 +16,7 @@ import setup_db
 import peyotl.ott as ott
 
 
-def load_taxonomy_using_copy(connection,cursor,otttable,syntable,path):
+def load_taxonomy_using_copy(connection,cursor,otttable,syntable):
     print "Loading taxonomy into memory"
     # if OTT dir not specified, uses path from peyotl config
     taxonomy = ott.OTT()
@@ -103,18 +103,10 @@ if __name__ == "__main__":
         print e.pgerror
 
     try:
-        ott_loc = config_dict['taxonomy']
-        # TODO: convert ott_loc to a full path
-        if ott_loc == 'None':
-            print 'No taxonomy'
-        if os.path.isdir(ott_loc):
-            # data import
-            starttime = dt.datetime.now()
-            load_taxonomy_using_copy(connection,cursor,TAXONOMYTABLE,SYNONYMTABLE,ott_loc)
-            endtime = dt.datetime.now()
-            print "OTT load time: ",endtime - starttime
-        else:
-            print "{o} is not directory".format(o=ott_loc)
+        starttime = dt.datetime.now()
+        load_taxonomy_using_copy(connection,cursor,TAXONOMYTABLE,SYNONYMTABLE)
+        endtime = dt.datetime.now()
+        print "OTT load time: ",endtime - starttime
     except psy.Error as e:
         print e.pgerror
     connection.close()

--- a/otindex/scripts/run_setup_scripts.sh
+++ b/otindex/scripts/run_setup_scripts.sh
@@ -13,8 +13,7 @@ fi
 config=$1
 
 if [ $nstudies ]; then
-    # delete existing tables, re-create
-    python setup_db.py -d $config
+    python setup_db.py $config
 
     # load nexson files
     python load_nexson.py $config -n $nstudies
@@ -31,8 +30,8 @@ if [ $nstudies ]; then
     exit 0
 fi
 
-# delete existing table, re-create
-python setup_db.py -d $config
+# clear existing tables
+python setup_db.py $config
 
 # load nexson files
 python load_nexson.py $config

--- a/otindex/scripts/setup_db.py
+++ b/otindex/scripts/setup_db.py
@@ -5,22 +5,18 @@
 # Changes to table structure must be replicated in ../models.py
 
 import argparse
-import yaml
+from ConfigParser import SafeConfigParser
 import psycopg2 as psy
 import simplejson as json
-#import logging
 import pdb
 
-def clear_gin_index(connection,cursor,config_dict):
+def clear_gin_index(connection,cursor):
     print 'clearing GIN indexes'
-
     # study table
-    STUDYGININDEX=config_dict['studyginindex']
-    sqlstring = "DROP INDEX IF EXISTS {indexname};".format(indexname=STUDYGININDEX)
+    sqlstring = "DROP INDEX IF EXISTS study_ix_jsondata_gin;"
     cursor.execute(sqlstring)
     # tree table
-    TREEGININDEX=config_dict['treeginindex']
-    sqlstring = "DROP INDEX IF EXISTS {indexname};".format(indexname=TREEGININDEX)
+    sqlstring = "DROP INDEX IF EXISTS tree_ix_jsondata_gin
     cursor.execute(sqlstring)
 
     connection.commit()
@@ -30,10 +26,10 @@ def clear_single_table(connection,cursor,tablename):
     sqlstring=('TRUNCATE {t} CASCADE;').format(t=tablename)
     cursor.execute(sqlstring)
 
-def clear_tables(connection,cursor,config_dict):
+def clear_tables(connection,cursor,config_obj):
     print 'clearing tables'
     # tree linked to study via foreign key, so cascade removes both
-    tabledict = config_dict['tables']
+    tabledict = dict(config_obj.items('database_tables'))
     for table in tabledict:
         name = tabledict[table]
         sqlstring=('TRUNCATE {t} CASCADE;'
@@ -42,19 +38,22 @@ def clear_tables(connection,cursor,config_dict):
         #print '  SQL: ',cursor.mogrify(sqlstring)
         cursor.execute(sqlstring)
 
-def connect(config_dict):
+def connect(config_obj):
     conn = cursor = None  # not sure of exception intent
     try:
-        DBNAME = config_dict['connection_info']['dbname']
-        USER = config_dict['connection_info']['user']
+        DBNAME = config_obj.get('connection_info','dbname')
+        USER = config_obj.get('connection_info','dbuser')
         HOST = 'localhost'
-        connectionstring=("dbname={dbname} "
-            "host={h} "
-            "user={dbuser}"
-            .format(dbname=DBNAME,h=HOST,dbuser=USER)
-            )
-        if 'password' in config_dict['connection_info']:
-            PASSWORD = config_dict['connection_info']['password']
+        connectionstring = ""
+        PASSWORD = config_obj.get('connection_info','password')
+        # if there is no password specified
+        if password == '':
+            connectionstring=("dbname={dbname} "
+                "host={h} "
+                "user={dbuser}"
+                .format(dbname=DBNAME,h=HOST,dbuser=USER)
+                )
+        else:
             connectionstring=("dbname={dbname} "
                 "user={dbuser} "
                 "host={h} "
@@ -63,6 +62,8 @@ def connect(config_dict):
                 )
         conn = psy.connect(connectionstring)
         cursor = conn.cursor()
+    except NoSectionError as e:
+        print "Error reading config file; {m}".format(m=e.Error)
     except KeyboardInterrupt:
         print "Shutdown requested because could not connect to DB"
     except psy.Error as e:
@@ -85,9 +86,9 @@ def create_table(connection,cursor,tablename,tablestring):
 # Function to create all database tables
 # Any changes made to the tablestring should also be reflected in
 # otindex/models.py
-def create_all_tables(connection,cursor,config_dict):
+def create_all_tables(connection,cursor,config_obj):
     # study table
-    STUDYTABLE = config_dict['tables']['studytable']
+    STUDYTABLE = config_obj.get('database_tables','studytable')
     tablestring = ('CREATE TABLE {tablename} '
         '(id text PRIMARY KEY, '
         'ntrees integer, '
@@ -98,7 +99,7 @@ def create_all_tables(connection,cursor,config_dict):
     create_table(connection,cursor,STUDYTABLE,tablestring)
 
     # tree table
-    TREETABLE = config_dict['tables']['treetable']
+    TREETABLE = config_obj.get('database_tables','treetable')
     tablestring = ('CREATE TABLE {tablename} '
         '(id serial PRIMARY KEY, '
         'tree_id text NOT NULL, '
@@ -112,7 +113,7 @@ def create_all_tables(connection,cursor,config_dict):
     create_table(connection,cursor,TREETABLE,tablestring)
 
     # curator table
-    CURATORTABLE = config_dict['tables']['curatortable']
+    CURATORTABLE = config_obj.get('database_tables','curatortable')
     tablestring = ('CREATE TABLE {tablename} '
         '(id serial PRIMARY KEY, '
         'name text UNIQUE);'
@@ -121,7 +122,7 @@ def create_all_tables(connection,cursor,config_dict):
     create_table(connection,cursor,CURATORTABLE,tablestring)
 
     # study-curator table
-    CURATORSTUDYTABLE = config_dict['tables']['curatorstudytable']
+    CURATORSTUDYTABLE = config_obj.get('database_tables','curatorstudytable')
     tablestring = ('CREATE TABLE {tablename} '
         '(curator_id int REFERENCES curator (id) ON DELETE CASCADE,'
         'study_id text REFERENCES study (id) ON DELETE CASCADE);'
@@ -130,7 +131,7 @@ def create_all_tables(connection,cursor,config_dict):
     create_table(connection,cursor,CURATORSTUDYTABLE,tablestring)
 
     # taxonomy table
-    TAXONOMYTABLE = config_dict['tables']['otttable']
+    TAXONOMYTABLE = config_obj.get('database_tables','otttable')
     tablestring = ('CREATE TABLE {tablename} '
         '(id int PRIMARY KEY, '
         'name text, '
@@ -140,7 +141,7 @@ def create_all_tables(connection,cursor,config_dict):
     create_table(connection,cursor,TAXONOMYTABLE,tablestring)
 
     # otu-tree table
-    TREEOTUTABLE = config_dict['tables']['treeotutable']
+    TREEOTUTABLE = config_obj.get('database_tables','treeotutable')
     tablestring = ('CREATE TABLE {tablename} '
         '(tree_id int REFERENCES tree (id) ON DELETE CASCADE, '
         'ott_id int REFERENCES taxonomy (id) ON DELETE CASCADE);'
@@ -149,7 +150,7 @@ def create_all_tables(connection,cursor,config_dict):
     create_table(connection,cursor,TREEOTUTABLE,tablestring)
 
     # synonym table
-    SYNONYMTABLE = config_dict['tables']['synonymtable']
+    SYNONYMTABLE = config_obj.get('database_tables','synonymtable')
     tablestring = ('CREATE TABLE {tablename} '
         '(id int REFERENCES taxonomy (id) ON DELETE CASCADE, '
         'synonym text);'
@@ -158,7 +159,7 @@ def create_all_tables(connection,cursor,config_dict):
     create_table(connection,cursor,SYNONYMTABLE,tablestring)
 
     # property table
-    PROPERTYTABLE = config_dict['tables']['propertytable']
+    PROPERTYTABLE = config_obj.get('database_tables','propertytable')
     tablestring = ('CREATE TABLE {tablename} '
         '(id serial PRIMARY KEY, '
         'property text, '
@@ -181,30 +182,28 @@ def delete_table(connection,cursor,tablename):
     except psy.ProgrammingError, ex:
         print 'Error deleting table {name}'.format(name=tablename)
 
-def delete_all_tables(connection,cursor,config_dict):
+def delete_all_tables(connection,cursor,config_obj):
     print 'deleting tables'
-    tabledict = config_dict['tables']
+    tabledict = dict(config_obj.items('database_tables'))
     for table in tabledict:
         name = tabledict[table]
         delete_table(connection,cursor,name)
 
-def index_json_columns(connection,cursor,config_dict):
+def index_json_columns(connection,cursor,config_obj):
     #print "creating GIN index on JSONB columns in TREE and STUDY tables"
     try:
         # STUDY INDEX
-        STUDYGININDEX=config_dict['studyginindex']
-        STUDYTABLE = config_dict['tables']['studytable']
-        sqlstring = ('CREATE INDEX {indexname} on {tablename} '
+        STUDYTABLE = config_obj.get('database_tables','studytable')
+        sqlstring = ('CREATE INDEX study_ix_jsondata_gin on {tablename} '
             'USING gin({column});'
-            .format(indexname=STUDYGININDEX,tablename=STUDYTABLE,column='data'))
+            .format(tablename=STUDYTABLE,column='data'))
         cursor.execute(sqlstring)
         connection.commit()
         # TREE INDEX
-        TREEGININDEX=config_dict['treeginindex']
-        TREETABLE = config_dict['tables']['treetable']
-        sqlstring = ('CREATE INDEX {indexname} on {tablename} '
+        TREETABLE = config_obj.get('database_tables','treetable')
+        sqlstring = ('CREATE INDEX tree_ix_jsondata_gin on {tablename} '
             'USING gin({column});'
-            .format(indexname=TREEGININDEX,tablename=TREETABLE,column='data'))
+            .format(tablename=TREETABLE,column='data'))
         cursor.execute(sqlstring)
         connection.commit()
     except psy.ProgrammingError, ex:
@@ -219,16 +218,13 @@ def import_csv_file(connection,cursor,table,filename):
         cursor.copy_expert(copystring,f)
         connection.commit()
 
-# Config file contains these variables
-# connection_info:
-#   dbname, user
-# tables:
-#   curatorstudytable, otutable, curatortable, treetable, studytable
-# ginindex:
+# Config file contains these sections
+#  connection_info
+#  tables
 def read_config(configfile):
-    with open(configfile,'r') as f:
-        config_dict = yaml.safe_load(f)
-        return config_dict
+    config_obj = ConfigParser.ConfigParser()
+    config_obj.read(configfile)
+    return config_obj
 
 def table_exists(cursor, tablename):
     sqlstring = ("SELECT EXISTS (SELECT 1 "
@@ -239,11 +235,6 @@ def table_exists(cursor, tablename):
         )
     cursor.execute(sqlstring)
     return cursor.fetchone()[0]
-
-# TODO: need to hook this in, probably through config file
-# def get_logger(name='otindex'):
-#     logger = logging.getLogger(name)
-#     logger.basicConfig(filename='setup_db.log',level=logging.INFO)
 
 if __name__ == "__main__":
     # get command line argument (option to delete tables and start over)
@@ -261,16 +252,16 @@ if __name__ == "__main__":
 
     args = parser.parse_args()
 
-    config_dict = read_config(args.configfile)
-    connection, cursor = connect(config_dict)
+    config_obj = read_config(args.configfile)
+    connection, cursor = connect(config_obj)
 
     if connection != None:
         try:
             if (args.delete_tables):
-                delete_all_tables(connection,cursor,config_dict)
-                create_all_tables(connection,cursor,config_dict)
+                delete_all_tables(connection,cursor,config_obj)
+                create_all_tables(connection,cursor,config_obj)
             else:
-                clear_tables(connection,cursor,config_dict)
+                clear_tables(connection,cursor,config_obj)
         except psy.Error as e:
             print e.pgerror
 

--- a/otindex/scripts/setup_db.py
+++ b/otindex/scripts/setup_db.py
@@ -5,7 +5,7 @@
 # Changes to table structure must be replicated in ../models.py
 
 import argparse
-from ConfigParser import SafeConfigParser
+import ConfigParser
 import psycopg2 as psy
 import simplejson as json
 import pdb
@@ -16,7 +16,7 @@ def clear_gin_index(connection,cursor):
     sqlstring = "DROP INDEX IF EXISTS study_ix_jsondata_gin;"
     cursor.execute(sqlstring)
     # tree table
-    sqlstring = "DROP INDEX IF EXISTS tree_ix_jsondata_gin
+    sqlstring = "DROP INDEX IF EXISTS tree_ix_jsondata_gin;"
     cursor.execute(sqlstring)
 
     connection.commit()
@@ -47,7 +47,7 @@ def connect(config_obj):
         connectionstring = ""
         PASSWORD = config_obj.get('connection_info','password')
         # if there is no password specified
-        if password == '':
+        if PASSWORD == '':
             connectionstring=("dbname={dbname} "
                 "host={h} "
                 "user={dbuser}"
@@ -62,7 +62,7 @@ def connect(config_obj):
                 )
         conn = psy.connect(connectionstring)
         cursor = conn.cursor()
-    except NoSectionError as e:
+    except ConfigParser.NoSectionError as e:
         print "Error reading config file; {m}".format(m=e.Error)
     except KeyboardInterrupt:
         print "Shutdown requested because could not connect to DB"
@@ -152,7 +152,8 @@ def create_all_tables(connection,cursor,config_obj):
     # synonym table
     SYNONYMTABLE = config_obj.get('database_tables','synonymtable')
     tablestring = ('CREATE TABLE {tablename} '
-        '(id int REFERENCES taxonomy (id) ON DELETE CASCADE, '
+        '(id serial PRIMARY KEY, '
+        'ott_id int REFERENCES taxonomy (id) ON DELETE CASCADE, '
         'synonym text);'
         .format(tablename=SYNONYMTABLE)
     )
@@ -214,7 +215,7 @@ def index_json_columns(connection,cursor,config_obj):
 def import_csv_file(connection,cursor,table,filename):
     print "copying {f} into {t} table".format(f=filename,t=table)
     with open (filename,'r') as f:
-        copystring="COPY {t} FROM STDIN WITH CSV HEADER".format(t=table)
+        copystring="COPY {t}  FROM STDIN WITH CSV HEADER".format(t=table)
         cursor.copy_expert(copystring,f)
         connection.commit()
 
@@ -222,7 +223,7 @@ def import_csv_file(connection,cursor,table,filename):
 #  connection_info
 #  tables
 def read_config(configfile):
-    config_obj = ConfigParser.ConfigParser()
+    config_obj = ConfigParser.SafeConfigParser()
     config_obj.read(configfile)
     return config_obj
 

--- a/otindex/scripts/setup_db.py
+++ b/otindex/scripts/setup_db.py
@@ -240,7 +240,7 @@ if __name__ == "__main__":
     # get command line argument (option to delete tables and start over)
     parser = argparse.ArgumentParser(description='set up database tables')
     parser.add_argument('configfile',
-        help='path to the config file'
+        help='path to the development.ini file'
         )
 
     parser.add_argument('-d',

--- a/otindex/scripts/test_db_selects.py
+++ b/otindex/scripts/test_db_selects.py
@@ -5,38 +5,32 @@ import argparse
 import yaml
 import setup_db
 
-def find_all_studies(cursor,config_dict):
-    STUDYTABLE = config_dict['tables']['studytable']
+def find_all_studies(cursor,config_obj):
+    STUDYTABLE = config_obj.get('database_tables','studytable')
     sqlstring = "SELECT id FROM {t};".format(t=STUDYTABLE)
     cursor.execute(sqlstring)
     print "returned",cursor.rowcount,"studies"
 
-def find_all_trees(cursor,config_dict):
-    TREETABLE = config_dict['tables']['treetable']
+def find_all_trees(cursor,config_obj):
+    TREETABLE = config_obj.get('database_tables','treetable')
     sqlstring = "SELECT tree_id FROM {t};".format(t=TREETABLE)
     cursor.execute(sqlstring)
     print "returned",cursor.rowcount,"trees"
 
-def find_all_curators(cursor,config_dict):
-    CURATORTABLE = config_dict['tables']['curatortable']
+def find_all_curators(cursor,config_obj):
+    CURATORTABLE = config_obj.get('database_tables','curatortable')
     sqlstring = "SELECT * FROM {t};".format(t=CURATORTABLE)
     cursor.execute(sqlstring)
     print "returned",cursor.rowcount,"curators"
 
-def find_all_taxa(cursor,config_dict):
-    TAXONOMYTABLE = config_dict['tables']['otttable']
+def find_all_taxa(cursor,config_obj):
+    TAXONOMYTABLE = config_obj.get('database_tables','otttable')
     sqlstring = "SELECT * FROM {t};".format(t=TAXONOMYTABLE)
     cursor.execute(sqlstring)
     print "returned",cursor.rowcount,"taxa"
 
-def find_all_otus(cursor,config_dict):
-    OTUTABLE = config_dict['tables']['otutable']
-    sqlstring = "SELECT * FROM {t};".format(t=OTUTABLE)
-    cursor.execute(sqlstring)
-    print "returned",cursor.rowcount,"otus"
-
-def find_properties(cursor,config_dict):
-    PROPERTYTABLE = config_dict['tables']['propertytable']
+def find_properties(cursor,config_obj):
+    PROPERTYTABLE = config_obj.get('database_tables','propertytable')
     sqlstring = "SELECT * FROM {t} where type='study';".format(t=PROPERTYTABLE)
     cursor.execute(sqlstring)
     print "returned",cursor.rowcount,"study properties"
@@ -44,11 +38,11 @@ def find_properties(cursor,config_dict):
     cursor.execute(sqlstring)
     print "returned",cursor.rowcount,"tree properties"
 
-def connect(config_dict):
+def connect(config_obj):
     conn = cursor = None  # not sure of exception intent
     try:
-        DBNAME = config_dict['connection_info']['dbname']
-        USER = config_dict['connection_info']['user']
+        DBNAME = config_obj.get('connection_info','dbname')
+        USER = config_obj.get('connection_info','dbuser')
         connectionstring=("dbname={dbname} "
             "user={dbuser}"
             .format(dbname=DBNAME,dbuser=USER)
@@ -71,19 +65,16 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # read config variables
-    config_dict={}
-    with open(args.configfile,'r') as f:
-        config_dict = yaml.safe_load(f)
+    config_obj = setup_db.read_config(configfile)
 
-    connection, cursor = setup_db.connect(config_dict)
-    
+    connection, cursor = setup_db.connect(config_obj)
+
     try:
-        find_all_studies(cursor,config_dict)
-        find_all_trees(cursor,config_dict)
-        find_all_curators(cursor,config_dict)
-        #find_all_otus(cursor,config_dict)
-        find_all_taxa(cursor,config_dict)
-        find_properties(cursor,config_dict)
+        find_all_studies(cursor,config_obj)
+        find_all_trees(cursor,config_obj)
+        find_all_curators(cursor,config_obj)
+        find_all_taxa(cursor,config_obj)
+        find_properties(cursor,config_obj)
     except psy.Error as e:
         print e.pgerror
     connection.close()

--- a/otindex/scripts/test_db_selects.py
+++ b/otindex/scripts/test_db_selects.py
@@ -60,7 +60,7 @@ if __name__ == "__main__":
     print "testing DB selects"
     parser = argparse.ArgumentParser(description='simple DB select tests')
     parser.add_argument('configfile',
-        help='path to the config file'
+        help='path to the development.ini file'
         )
     args = parser.parse_args()
 

--- a/otindex/scripts/test_db_selects.py
+++ b/otindex/scripts/test_db_selects.py
@@ -65,7 +65,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
 
     # read config variables
-    config_obj = setup_db.read_config(configfile)
+    config_obj = setup_db.read_config(args.configfile)
 
     connection, cursor = setup_db.connect(config_obj)
 

--- a/otindex/scripts/test_db_setup.py
+++ b/otindex/scripts/test_db_setup.py
@@ -12,7 +12,7 @@ class TestDatabaseSetup():
 
     def setUp(self):
         # read config file
-        self.config_obj = setup_db.read_config('../development.ini')
+        self.config_obj = setup_db.read_config('../../development.ini')
         self.connection_tuple = setup_db.connect(self.config_obj)
 
     def tearDown(self):

--- a/otindex/scripts/test_db_setup.py
+++ b/otindex/scripts/test_db_setup.py
@@ -7,13 +7,13 @@ import unittest
 
 class TestDatabaseSetup():
     def __init__(self):
-        self.config_dict = {}
+        self.config_obj = {}
         self.connection_tuple = ()
 
     def setUp(self):
         # read config file
-        self.config_dict = setup_db.read_config('config.yml')
-        self.connection_tuple = setup_db.connect(self.config_dict)
+        self.config_obj = setup_db.read_config('../development.ini')
+        self.connection_tuple = setup_db.connect(self.config_obj)
 
     def tearDown(self):
         connection,cursor = self.connection_tuple


### PR DESCRIPTION
Doing this as a PR just as a heads up to @mtholder and @jar398 who are I think the only ones who have tried to install otindex (I can merge this myself tomorrow). 

I've changed the config files so that instead of using a yaml config file to load the data, and a INI file to run pyramid, all of the config is in one `development.ini` / `production.ini` file. This makes ansible deployment much simpler, and is also more consistent with peyotl. 

I also now (by default) use the location of OTT in the peyotl config, rather than having the OTT location specified in both the otindex config and the peyotl config. This is easy to override when deploying using ansible. 
