### PR TITLE
pass tree json directly

### DIFF
--- a/otindex/add_update_studies.py
+++ b/otindex/add_update_studies.py
@@ -88,12 +88,11 @@ def add_study(study_id):
         if (tree_id in proposedTrees):
             proposedForSynth = True
 
-        treejson = json.dumps(tree)
         new_tree = Tree(
             tree_id=tree_id,
             study_id=study_id,
             proposed=proposedForSynth,
-            data=treejson
+            data=tree
             )
 
         # get otus


### PR DESCRIPTION
Tree json was getting ingested as a string instead of a dict on update, making keys not searchable, and returning "null" from the index for all tree properties. This updates to passing the tree directly, and fixes issue https://github.com/OpenTreeOfLife/otindex/issues/48

Deployed on dev (via otindexdev)